### PR TITLE
refactor: Introduce GeneratorOptions

### DIFF
--- a/src/Avalonia.NameGenerator.Tests/InitializeComponent/GeneratedCode/AttachedProps.txt
+++ b/src/Avalonia.NameGenerator.Tests/InitializeComponent/GeneratedCode/AttachedProps.txt
@@ -7,7 +7,7 @@ namespace Sample.App
 {
     partial class SampleView
     {
-        internal global::Avalonia.Controls.TextBox UserNameTextBox {get; set;}
+        internal global::Avalonia.Controls.TextBox UserNameTextBox { get; set; }
 
         public void InitializeComponent(bool loadXaml = true)
         {

--- a/src/Avalonia.NameGenerator.Tests/InitializeComponent/GeneratedCode/CustomControls.txt
+++ b/src/Avalonia.NameGenerator.Tests/InitializeComponent/GeneratedCode/CustomControls.txt
@@ -7,9 +7,9 @@ namespace Sample.App
 {
     partial class SampleView
     {
-        internal global::Avalonia.ReactiveUI.RoutedViewHost ClrNamespaceRoutedViewHost {get; set;}
-        internal global::Avalonia.ReactiveUI.RoutedViewHost UriRoutedViewHost {get; set;}
-        internal global::Controls.CustomTextBox UserNameTextBox {get; set;}
+        internal global::Avalonia.ReactiveUI.RoutedViewHost ClrNamespaceRoutedViewHost { get; set; }
+        internal global::Avalonia.ReactiveUI.RoutedViewHost UriRoutedViewHost { get; set; }
+        internal global::Controls.CustomTextBox UserNameTextBox { get; set; }
 
         public void InitializeComponent(bool loadXaml = true)
         {

--- a/src/Avalonia.NameGenerator.Tests/InitializeComponent/GeneratedCode/DataTemplates.txt
+++ b/src/Avalonia.NameGenerator.Tests/InitializeComponent/GeneratedCode/DataTemplates.txt
@@ -7,8 +7,8 @@ namespace Sample.App
 {
     partial class SampleView
     {
-        internal global::Avalonia.Controls.TextBox UserNameTextBox {get; set;}
-        internal global::Avalonia.Controls.ListBox NamedListBox {get; set;}
+        internal global::Avalonia.Controls.TextBox UserNameTextBox { get; set; }
+        internal global::Avalonia.Controls.ListBox NamedListBox { get; set; }
 
         public void InitializeComponent(bool loadXaml = true)
         {

--- a/src/Avalonia.NameGenerator.Tests/InitializeComponent/GeneratedCode/FieldModifier.txt
+++ b/src/Avalonia.NameGenerator.Tests/InitializeComponent/GeneratedCode/FieldModifier.txt
@@ -7,12 +7,12 @@ namespace Sample.App
 {
     partial class SampleView
     {
-        public global::Avalonia.Controls.TextBox FirstNameTextBox {get; set;}
-        public global::Avalonia.Controls.TextBox LastNameTextBox {get; set;}
-        protected global::Avalonia.Controls.TextBox PasswordTextBox {get; set;}
-        private global::Avalonia.Controls.TextBox ConfirmPasswordTextBox {get; set;}
-        internal global::Avalonia.Controls.Button SignUpButton {get; set;}
-        internal global::Avalonia.Controls.Button RegisterButton {get; set;}
+        public global::Avalonia.Controls.TextBox FirstNameTextBox { get; set; }
+        public global::Avalonia.Controls.TextBox LastNameTextBox { get; set; }
+        protected global::Avalonia.Controls.TextBox PasswordTextBox { get; set; }
+        private global::Avalonia.Controls.TextBox ConfirmPasswordTextBox { get; set; }
+        internal global::Avalonia.Controls.Button SignUpButton { get; set; }
+        internal global::Avalonia.Controls.Button RegisterButton { get; set; }
 
         public void InitializeComponent(bool loadXaml = true)
         {

--- a/src/Avalonia.NameGenerator.Tests/InitializeComponent/GeneratedCode/NamedControl.txt
+++ b/src/Avalonia.NameGenerator.Tests/InitializeComponent/GeneratedCode/NamedControl.txt
@@ -7,7 +7,7 @@ namespace Sample.App
 {
     partial class SampleView
     {
-        internal global::Avalonia.Controls.TextBox UserNameTextBox {get; set;}
+        internal global::Avalonia.Controls.TextBox UserNameTextBox { get; set; }
 
         public void InitializeComponent(bool loadXaml = true)
         {

--- a/src/Avalonia.NameGenerator.Tests/InitializeComponent/GeneratedCode/NamedControls.txt
+++ b/src/Avalonia.NameGenerator.Tests/InitializeComponent/GeneratedCode/NamedControls.txt
@@ -7,9 +7,9 @@ namespace Sample.App
 {
     partial class SampleView
     {
-        internal global::Avalonia.Controls.TextBox UserNameTextBox {get; set;}
-        internal global::Avalonia.Controls.TextBox PasswordTextBox {get; set;}
-        internal global::Avalonia.Controls.Button SignUpButton {get; set;}
+        internal global::Avalonia.Controls.TextBox UserNameTextBox { get; set; }
+        internal global::Avalonia.Controls.TextBox PasswordTextBox { get; set; }
+        internal global::Avalonia.Controls.Button SignUpButton { get; set; }
 
         public void InitializeComponent(bool loadXaml = true)
         {

--- a/src/Avalonia.NameGenerator.Tests/InitializeComponent/GeneratedCode/SignUpView.txt
+++ b/src/Avalonia.NameGenerator.Tests/InitializeComponent/GeneratedCode/SignUpView.txt
@@ -7,15 +7,15 @@ namespace Sample.App
 {
     partial class SampleView
     {
-        internal global::Controls.CustomTextBox UserNameTextBox {get; set;}
-        internal global::Avalonia.Controls.TextBlock UserNameValidation {get; set;}
-        internal global::Avalonia.Controls.TextBox PasswordTextBox {get; set;}
-        internal global::Avalonia.Controls.TextBlock PasswordValidation {get; set;}
-        internal global::Avalonia.Controls.ListBox AwesomeListView {get; set;}
-        internal global::Avalonia.Controls.TextBox ConfirmPasswordTextBox {get; set;}
-        internal global::Avalonia.Controls.TextBlock ConfirmPasswordValidation {get; set;}
-        internal global::Avalonia.Controls.Button SignUpButton {get; set;}
-        internal global::Avalonia.Controls.TextBlock CompoundValidation {get; set;}
+        internal global::Controls.CustomTextBox UserNameTextBox { get; set; }
+        internal global::Avalonia.Controls.TextBlock UserNameValidation { get; set; }
+        internal global::Avalonia.Controls.TextBox PasswordTextBox { get; set; }
+        internal global::Avalonia.Controls.TextBlock PasswordValidation { get; set; }
+        internal global::Avalonia.Controls.ListBox AwesomeListView { get; set; }
+        internal global::Avalonia.Controls.TextBox ConfirmPasswordTextBox { get; set; }
+        internal global::Avalonia.Controls.TextBlock ConfirmPasswordValidation { get; set; }
+        internal global::Avalonia.Controls.Button SignUpButton { get; set; }
+        internal global::Avalonia.Controls.TextBlock CompoundValidation { get; set; }
 
         public void InitializeComponent(bool loadXaml = true)
         {

--- a/src/Avalonia.NameGenerator.Tests/InitializeComponent/GeneratedCode/xNamedControl.txt
+++ b/src/Avalonia.NameGenerator.Tests/InitializeComponent/GeneratedCode/xNamedControl.txt
@@ -7,7 +7,7 @@ namespace Sample.App
 {
     partial class SampleView
     {
-        internal global::Avalonia.Controls.TextBox UserNameTextBox {get; set;}
+        internal global::Avalonia.Controls.TextBox UserNameTextBox { get; set; }
 
         public void InitializeComponent(bool loadXaml = true)
         {

--- a/src/Avalonia.NameGenerator.Tests/InitializeComponent/GeneratedCode/xNamedControls.txt
+++ b/src/Avalonia.NameGenerator.Tests/InitializeComponent/GeneratedCode/xNamedControls.txt
@@ -7,9 +7,9 @@ namespace Sample.App
 {
     partial class SampleView
     {
-        internal global::Avalonia.Controls.TextBox UserNameTextBox {get; set;}
-        internal global::Avalonia.Controls.TextBox PasswordTextBox {get; set;}
-        internal global::Avalonia.Controls.Button SignUpButton {get; set;}
+        internal global::Avalonia.Controls.TextBox UserNameTextBox { get; set; }
+        internal global::Avalonia.Controls.TextBox PasswordTextBox { get; set; }
+        internal global::Avalonia.Controls.Button SignUpButton { get; set; }
 
         public void InitializeComponent(bool loadXaml = true)
         {

--- a/src/Avalonia.NameGenerator/AvaloniaNameSourceGenerator.cs
+++ b/src/Avalonia.NameGenerator/AvaloniaNameSourceGenerator.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Avalonia.NameGenerator.Compiler;
 using Avalonia.NameGenerator.Domain;
@@ -11,21 +10,9 @@ using Microsoft.CodeAnalysis.CSharp;
 
 namespace Avalonia.NameGenerator
 {
-    public enum BuildProperties
-    {
-        AvaloniaNameGeneratorBehavior = 0
-    }
-    
-    public enum Behaviors
-    {
-        OnlyProperties = 0,
-        InitializeComponent,
-    }
-    
     [Generator]
     public class AvaloniaNameSourceGenerator : ISourceGenerator
     {
-
         public void Initialize(GeneratorInitializationContext context) { }
 
         public void Execute(GeneratorExecutionContext context)
@@ -33,21 +20,14 @@ namespace Avalonia.NameGenerator
             var compilation = (CSharpCompilation)context.Compilation;
             var types = new RoslynTypeSystem(compilation);
             var compiler = MiniCompiler.CreateDefault(types, MiniCompiler.AvaloniaXmlnsDefinitionAttribute);
-            
-            var behaviorName = context.GetMSBuildProperty(nameof(BuildProperties.AvaloniaNameGeneratorBehavior), "");
-            
-            if(!Behaviors.TryParse(behaviorName, out Behaviors behavior))
-            {
-                behavior = Behaviors.OnlyProperties;
-            }
-            
-            ICodeGenerator generator = behavior switch {
-                Behaviors.OnlyProperties => new OnlyPropertiesCodeGenerator(),
-                Behaviors.InitializeComponent => new InitializeComponentCodeGenerator(),
+
+            var options = new GeneratorOptions(context);
+            ICodeGenerator generator = options.AvaloniaNameGeneratorBehavior switch {
+                Behavior.OnlyProperties => new OnlyPropertiesCodeGenerator(),
+                Behavior.InitializeComponent => new InitializeComponentCodeGenerator(),
                 _ => throw new ArgumentOutOfRangeException()
             };
-            
-            
+
             INameGenerator avaloniaNameGenerator =
                 new AvaloniaNameGenerator(
                     new XamlXViewResolver(types, compiler, true, type => ReportInvalidType(context, type)),

--- a/src/Avalonia.NameGenerator/Generator.props
+++ b/src/Avalonia.NameGenerator/Generator.props
@@ -1,11 +1,11 @@
 ﻿<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <AvaloniaNameGeneratorBehavior Condition="'$(AvaloniaNameGeneratorBehavior)' == ''">OnlyProperties</AvaloniaNameGeneratorBehavior>
+  </PropertyGroup>
   <ItemGroup>
     <CompilerVisibleItemMetadata Include="AdditionalFiles" MetadataName="SourceItemGroup"/>
     <CompilerVisibleProperty Include="AvaloniaNameGeneratorBehavior" />
   </ItemGroup>
-  <PropertyGroup>
-    <AvaloniaNameGeneratorBehavior Condition="'$(AvaloniaNameGeneratorBehavior)' == ''">OnlyProperties</AvaloniaNameGeneratorBehavior>
-  </PropertyGroup>
   <Target Name="_InjectAdditionalFiles" BeforeTargets="GenerateMSBuildEditorConfigFileShouldRun">
     <ItemGroup>
       <AdditionalFiles Include="@(AvaloniaXaml)" SourceItemGroup="AvaloniaXaml" />

--- a/src/Avalonia.NameGenerator/Generator/InitializeComponentCodeGenerator.cs
+++ b/src/Avalonia.NameGenerator/Generator/InitializeComponentCodeGenerator.cs
@@ -12,7 +12,7 @@ namespace Avalonia.NameGenerator.Generator
             var initializations = new List<string>();
             foreach (var info in names)
             {
-                properties.Add($"        {info.FieldModifier} global::{info.TypeName} {info.Name} {{get; set;}}");
+                properties.Add($"        {info.FieldModifier} global::{info.TypeName} {info.Name} {{ get; set; }}");
                 initializations.Add($"            {info.Name} = this.FindControl<global::{info.TypeName}>(\"{info.Name}\");");
             }
             

--- a/src/Avalonia.NameGenerator/GeneratorOptions.cs
+++ b/src/Avalonia.NameGenerator/GeneratorOptions.cs
@@ -1,0 +1,38 @@
+using System;
+using Microsoft.CodeAnalysis;
+
+namespace Avalonia.NameGenerator
+{
+    public enum BuildProperties
+    {
+        AvaloniaNameGeneratorBehavior = 0
+    }
+
+    public enum Behavior
+    {
+        OnlyProperties = 0,
+        InitializeComponent = 1,
+    }
+
+    public class GeneratorOptions
+    {
+        private readonly GeneratorExecutionContext _context;
+
+        public GeneratorOptions(GeneratorExecutionContext context) => _context = context;
+
+        public Behavior AvaloniaNameGeneratorBehavior
+        {
+            get
+            {
+                var propertyValue = _context
+                    .GetMSBuildProperty(
+                        nameof(BuildProperties.AvaloniaNameGeneratorBehavior),
+                        nameof(Behavior.OnlyProperties));
+
+                if (!Enum.TryParse(propertyValue, out Behavior behavior))
+                    return Behavior.OnlyProperties;
+                return behavior;
+            }
+        }
+    }
+}


### PR DESCRIPTION
As we are planning to introduce more options (https://github.com/AvaloniaUI/Avalonia.NameGenerator/issues/26, https://github.com/AvaloniaUI/Avalonia.NameGenerator/issues/25), let's centralize the management of options. Also, with this PR we are planning to ship a new XamlNameReferenceGenerator version with `InitializeComponent` and stuff https://github.com/AvaloniaUI/Avalonia.NameGenerator/pull/29