### PR TITLE
fix: Actually clear resolved names

### DIFF
--- a/src/Avalonia.NameGenerator/Generator/XamlXNameResolver.cs
+++ b/src/Avalonia.NameGenerator/Generator/XamlXNameResolver.cs
@@ -18,6 +18,7 @@ namespace Avalonia.NameGenerator.Generator
 
         public IReadOnlyList<ResolvedName> ResolveNames(XamlDocument xaml)
         {
+            _items.Clear();
             xaml.Root.Visit(this);
             xaml.Root.VisitChildren(this);
             return _items;

--- a/src/Avalonia.NameGenerator/Generator/XamlXViewResolver.cs
+++ b/src/Avalonia.NameGenerator/Generator/XamlXViewResolver.cs
@@ -79,8 +79,7 @@ namespace Avalonia.NameGenerator.Generator
                     var split = text.Text.Split('.');
                     var nameSpace = string.Join(".", split.Take(split.Length - 1));
                     var className = split.Last();
-                    
-                    
+
                     _resolvedClass = new ResolvedView(className, clrType, nameSpace, _xaml);
                     return node;
                 }


### PR DESCRIPTION
Currently, the names from all source files in the project are accumulated in the `_items` list. The PR fixes this.