### PR TITLE
build(deps): Bump Microsoft.CodeAnalysis.CSharp in /src

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.100-rc.2.20479.15
+        dotnet-version: 5.0.200
 
     - name: NBGV
       id: nbgv

--- a/src/Avalonia.NameGenerator.Tests/Avalonia.NameGenerator.Tests.csproj
+++ b/src/Avalonia.NameGenerator.Tests/Avalonia.NameGenerator.Tests.csproj
@@ -7,6 +7,7 @@
         <InstallAvalonia>true</InstallAvalonia>
     </PropertyGroup>
     <ItemGroup>
+        <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="3.9.0" />
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.9.0" />
         <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />

--- a/src/Avalonia.NameGenerator.Tests/Avalonia.NameGenerator.Tests.csproj
+++ b/src/Avalonia.NameGenerator.Tests/Avalonia.NameGenerator.Tests.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.8.0" />
-        <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="3.8.0" />
+        <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="3.9.0" />
         <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
         <PackageReference Include="xunit" Version="2.4.1" />

--- a/src/Avalonia.NameGenerator.Tests/Avalonia.NameGenerator.Tests.csproj
+++ b/src/Avalonia.NameGenerator.Tests/Avalonia.NameGenerator.Tests.csproj
@@ -7,8 +7,8 @@
         <InstallAvalonia>true</InstallAvalonia>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.8.0" />
         <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="3.9.0" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.9.0" />
         <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
         <PackageReference Include="xunit" Version="2.4.1" />

--- a/src/Avalonia.NameGenerator.Tests/Avalonia.NameGenerator.Tests.csproj
+++ b/src/Avalonia.NameGenerator.Tests/Avalonia.NameGenerator.Tests.csproj
@@ -7,7 +7,6 @@
         <InstallAvalonia>true</InstallAvalonia>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="3.9.0" />
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.9.0" />
         <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />

--- a/src/Avalonia.NameGenerator/Avalonia.NameGenerator.csproj
+++ b/src/Avalonia.NameGenerator/Avalonia.NameGenerator.csproj
@@ -8,7 +8,7 @@
         <NoPackageAnalysis>true</NoPackageAnalysis>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.8.0" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.9.0" PrivateAssets="all" />
         <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2" PrivateAssets="all" />
     </ItemGroup>
     <ItemGroup>


### PR DESCRIPTION
This cherry-picks dependabot PRs and removes direct reference to the `.Common` package.