### PR TITLE
Add comments to generated InitializeComponent

### DIFF
--- a/src/Avalonia.NameGenerator.Tests/InitializeComponent/GeneratedInitializeComponent/AttachedProps.txt
+++ b/src/Avalonia.NameGenerator.Tests/InitializeComponent/GeneratedInitializeComponent/AttachedProps.txt
@@ -10,6 +10,11 @@ namespace Sample.App
     {
         internal global::Avalonia.Controls.TextBox UserNameTextBox;
 
+        /// <summary>
+        /// Wires up the controls and optionally loads XAML markup and attaches dev tools (if Avalonia.Diagnostics package is referenced).
+        /// </summary>
+        /// <param name="loadXaml">Should the XAML be loaded into the component.</param>
+
         public void InitializeComponent(bool loadXaml = true)
         {
             if (loadXaml)

--- a/src/Avalonia.NameGenerator.Tests/InitializeComponent/GeneratedInitializeComponent/AttachedPropsWithDevTools.txt
+++ b/src/Avalonia.NameGenerator.Tests/InitializeComponent/GeneratedInitializeComponent/AttachedPropsWithDevTools.txt
@@ -10,6 +10,12 @@ namespace Sample.App
     {
         internal global::Avalonia.Controls.TextBox UserNameTextBox;
 
+        /// <summary>
+        /// Wires up the controls and optionally loads XAML markup and attaches dev tools (if Avalonia.Diagnostics package is referenced).
+        /// </summary>
+        /// <param name="loadXaml">Should the XAML be loaded into the component.</param>
+        /// <param name="attachDevTools">Should the dev tools be attached.</param>
+
         public void InitializeComponent(bool loadXaml = true, bool attachDevTools = true)
         {
             if (loadXaml)

--- a/src/Avalonia.NameGenerator.Tests/InitializeComponent/GeneratedInitializeComponent/ControlWithoutWindow.txt
+++ b/src/Avalonia.NameGenerator.Tests/InitializeComponent/GeneratedInitializeComponent/ControlWithoutWindow.txt
@@ -10,6 +10,11 @@ namespace Sample.App
     {
         internal global::Avalonia.Controls.TextBox UserNameTextBox;
 
+        /// <summary>
+        /// Wires up the controls and optionally loads XAML markup and attaches dev tools (if Avalonia.Diagnostics package is referenced).
+        /// </summary>
+        /// <param name="loadXaml">Should the XAML be loaded into the component.</param>
+
         public void InitializeComponent(bool loadXaml = true)
         {
             if (loadXaml)

--- a/src/Avalonia.NameGenerator.Tests/InitializeComponent/GeneratedInitializeComponent/CustomControls.txt
+++ b/src/Avalonia.NameGenerator.Tests/InitializeComponent/GeneratedInitializeComponent/CustomControls.txt
@@ -12,6 +12,11 @@ namespace Sample.App
         internal global::Avalonia.ReactiveUI.RoutedViewHost UriRoutedViewHost;
         internal global::Controls.CustomTextBox UserNameTextBox;
 
+        /// <summary>
+        /// Wires up the controls and optionally loads XAML markup and attaches dev tools (if Avalonia.Diagnostics package is referenced).
+        /// </summary>
+        /// <param name="loadXaml">Should the XAML be loaded into the component.</param>
+
         public void InitializeComponent(bool loadXaml = true)
         {
             if (loadXaml)

--- a/src/Avalonia.NameGenerator.Tests/InitializeComponent/GeneratedInitializeComponent/DataTemplates.txt
+++ b/src/Avalonia.NameGenerator.Tests/InitializeComponent/GeneratedInitializeComponent/DataTemplates.txt
@@ -11,6 +11,11 @@ namespace Sample.App
         internal global::Avalonia.Controls.TextBox UserNameTextBox;
         internal global::Avalonia.Controls.ListBox NamedListBox;
 
+        /// <summary>
+        /// Wires up the controls and optionally loads XAML markup and attaches dev tools (if Avalonia.Diagnostics package is referenced).
+        /// </summary>
+        /// <param name="loadXaml">Should the XAML be loaded into the component.</param>
+
         public void InitializeComponent(bool loadXaml = true)
         {
             if (loadXaml)

--- a/src/Avalonia.NameGenerator.Tests/InitializeComponent/GeneratedInitializeComponent/FieldModifier.txt
+++ b/src/Avalonia.NameGenerator.Tests/InitializeComponent/GeneratedInitializeComponent/FieldModifier.txt
@@ -15,6 +15,11 @@ namespace Sample.App
         internal global::Avalonia.Controls.Button SignUpButton;
         internal global::Avalonia.Controls.Button RegisterButton;
 
+        /// <summary>
+        /// Wires up the controls and optionally loads XAML markup and attaches dev tools (if Avalonia.Diagnostics package is referenced).
+        /// </summary>
+        /// <param name="loadXaml">Should the XAML be loaded into the component.</param>
+
         public void InitializeComponent(bool loadXaml = true)
         {
             if (loadXaml)

--- a/src/Avalonia.NameGenerator.Tests/InitializeComponent/GeneratedInitializeComponent/NamedControl.txt
+++ b/src/Avalonia.NameGenerator.Tests/InitializeComponent/GeneratedInitializeComponent/NamedControl.txt
@@ -10,6 +10,11 @@ namespace Sample.App
     {
         internal global::Avalonia.Controls.TextBox UserNameTextBox;
 
+        /// <summary>
+        /// Wires up the controls and optionally loads XAML markup and attaches dev tools (if Avalonia.Diagnostics package is referenced).
+        /// </summary>
+        /// <param name="loadXaml">Should the XAML be loaded into the component.</param>
+
         public void InitializeComponent(bool loadXaml = true)
         {
             if (loadXaml)

--- a/src/Avalonia.NameGenerator.Tests/InitializeComponent/GeneratedInitializeComponent/NamedControls.txt
+++ b/src/Avalonia.NameGenerator.Tests/InitializeComponent/GeneratedInitializeComponent/NamedControls.txt
@@ -12,6 +12,11 @@ namespace Sample.App
         internal global::Avalonia.Controls.TextBox PasswordTextBox;
         internal global::Avalonia.Controls.Button SignUpButton;
 
+        /// <summary>
+        /// Wires up the controls and optionally loads XAML markup and attaches dev tools (if Avalonia.Diagnostics package is referenced).
+        /// </summary>
+        /// <param name="loadXaml">Should the XAML be loaded into the component.</param>
+
         public void InitializeComponent(bool loadXaml = true)
         {
             if (loadXaml)

--- a/src/Avalonia.NameGenerator.Tests/InitializeComponent/GeneratedInitializeComponent/NoNamedControls.txt
+++ b/src/Avalonia.NameGenerator.Tests/InitializeComponent/GeneratedInitializeComponent/NoNamedControls.txt
@@ -10,6 +10,11 @@ namespace Sample.App
     {
 
 
+        /// <summary>
+        /// Wires up the controls and optionally loads XAML markup and attaches dev tools (if Avalonia.Diagnostics package is referenced).
+        /// </summary>
+        /// <param name="loadXaml">Should the XAML be loaded into the component.</param>
+
         public void InitializeComponent(bool loadXaml = true)
         {
             if (loadXaml)

--- a/src/Avalonia.NameGenerator.Tests/InitializeComponent/GeneratedInitializeComponent/SignUpView.txt
+++ b/src/Avalonia.NameGenerator.Tests/InitializeComponent/GeneratedInitializeComponent/SignUpView.txt
@@ -18,6 +18,11 @@ namespace Sample.App
         internal global::Avalonia.Controls.Button SignUpButton;
         internal global::Avalonia.Controls.TextBlock CompoundValidation;
 
+        /// <summary>
+        /// Wires up the controls and optionally loads XAML markup and attaches dev tools (if Avalonia.Diagnostics package is referenced).
+        /// </summary>
+        /// <param name="loadXaml">Should the XAML be loaded into the component.</param>
+
         public void InitializeComponent(bool loadXaml = true)
         {
             if (loadXaml)

--- a/src/Avalonia.NameGenerator.Tests/InitializeComponent/GeneratedInitializeComponent/xNamedControl.txt
+++ b/src/Avalonia.NameGenerator.Tests/InitializeComponent/GeneratedInitializeComponent/xNamedControl.txt
@@ -10,6 +10,11 @@ namespace Sample.App
     {
         internal global::Avalonia.Controls.TextBox UserNameTextBox;
 
+        /// <summary>
+        /// Wires up the controls and optionally loads XAML markup and attaches dev tools (if Avalonia.Diagnostics package is referenced).
+        /// </summary>
+        /// <param name="loadXaml">Should the XAML be loaded into the component.</param>
+
         public void InitializeComponent(bool loadXaml = true)
         {
             if (loadXaml)

--- a/src/Avalonia.NameGenerator.Tests/InitializeComponent/GeneratedInitializeComponent/xNamedControls.txt
+++ b/src/Avalonia.NameGenerator.Tests/InitializeComponent/GeneratedInitializeComponent/xNamedControls.txt
@@ -12,6 +12,11 @@ namespace Sample.App
         internal global::Avalonia.Controls.TextBox PasswordTextBox;
         internal global::Avalonia.Controls.Button SignUpButton;
 
+        /// <summary>
+        /// Wires up the controls and optionally loads XAML markup and attaches dev tools (if Avalonia.Diagnostics package is referenced).
+        /// </summary>
+        /// <param name="loadXaml">Should the XAML be loaded into the component.</param>
+
         public void InitializeComponent(bool loadXaml = true)
         {
             if (loadXaml)

--- a/src/Avalonia.NameGenerator/Generator/InitializeComponentCodeGenerator.cs
+++ b/src/Avalonia.NameGenerator/Generator/InitializeComponentCodeGenerator.cs
@@ -15,6 +15,9 @@ namespace Avalonia.NameGenerator.Generator
             }          
 #endif
 ";
+        private const string AttachDevToolsParameterDocumentation
+            = @"        /// <param name=""attachDevTools"">Should the dev tools be attached.</param>
+";
 
         public InitializeComponentCodeGenerator(IXamlTypeSystem types)
         {
@@ -45,6 +48,11 @@ namespace {nameSpace}
     {{
 {string.Join("\n", properties)}
 
+        /// <summary>
+        /// Wires up the controls and optionally loads XAML markup and attaches dev tools (if Avalonia.Diagnostics package is referenced).
+        /// </summary>
+        /// <param name=""loadXaml"">Should the XAML be loaded into the component.</param>
+{(attachDevTools ? AttachDevToolsParameterDocumentation : string.Empty)}
         public void InitializeComponent(bool loadXaml = true{(attachDevTools ? ", bool attachDevTools = true" : string.Empty)})
         {{
             if (loadXaml)


### PR DESCRIPTION
Adds comments to the generated `InitializeComponent()` method.

```csharp
/// <summary>
/// Wires up the controls and optionally loads XAML markup and attaches dev tools (if Avalonia.Diagnostics package is referenced).
/// </summary>
/// <param name="loadXaml">Should the XAML be loaded into the component.</param>
/// <param name="attachDevTools">Should the dev tools be attached.</param>

public void InitializeComponent(bool loadXaml = true, bool attachDevTools = true)
```
