### PR TITLE
fix: Resolve #54, Support Older .NET SDKs

### DIFF
--- a/src/Avalonia.NameGenerator.Tests/Avalonia.NameGenerator.Tests.csproj
+++ b/src/Avalonia.NameGenerator.Tests/Avalonia.NameGenerator.Tests.csproj
@@ -7,8 +7,8 @@
         <InstallAvalonia>true</InstallAvalonia>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.10.0" />
-        <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="3.10.0" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.9.0" />
+        <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="3.9.0" />
         <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
         <PackageReference Include="xunit" Version="2.4.1" />

--- a/src/Avalonia.NameGenerator/Avalonia.NameGenerator.csproj
+++ b/src/Avalonia.NameGenerator/Avalonia.NameGenerator.csproj
@@ -8,7 +8,7 @@
         <NoPackageAnalysis>true</NoPackageAnalysis>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.10.0" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.9.0" PrivateAssets="all" />
         <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2" PrivateAssets="all" />
     </ItemGroup>
     <ItemGroup>


### PR DESCRIPTION
Avalonia is referencing 3.9.0.