### PR TITLE
Check for Control base type since IControl interface is removed

### DIFF
--- a/src/Avalonia.NameGenerator/Generator/ResolverExtensions.cs
+++ b/src/Avalonia.NameGenerator/Generator/ResolverExtensions.cs
@@ -1,0 +1,33 @@
+﻿using System.Linq;
+using XamlX.TypeSystem;
+
+namespace Avalonia.NameGenerator.Generator;
+
+internal static class ResolverExtensions
+{
+	public static bool IsAvaloniaControl(this IXamlType clrType)
+	{
+		return clrType.HasControlBaseType() || clrType.HasIControlInterface();
+	}
+
+	private static bool HasControlBaseType(this IXamlType clrType)
+	{
+		// Check for the base type since IControl interface is removed.
+		// https://github.com/AvaloniaUI/Avalonia/pull/9553
+		if (clrType.FullName == "Avalonia.Controls.Control")
+			return true;
+
+		if (clrType.BaseType != null)
+			return IsAvaloniaControl(clrType.BaseType);
+
+		return false;
+	}
+
+	private static bool HasIControlInterface(this IXamlType clrType)
+	{
+		return clrType
+			.Interfaces
+			.Any(abstraction => abstraction.IsInterface &&
+			                    abstraction.FullName == "Avalonia.Controls.IControl");
+	}
+}

--- a/src/Avalonia.NameGenerator/Generator/XamlXNameResolver.cs
+++ b/src/Avalonia.NameGenerator/Generator/XamlXNameResolver.cs
@@ -31,12 +31,8 @@ internal class XamlXNameResolver : INameResolver, IXamlAstVisitor
             return node;
 
         var clrType = objectNode.Type.GetClrType();
-        var isAvaloniaControl = clrType
-            .Interfaces
-            .Any(abstraction => abstraction.IsInterface &&
-                                abstraction.FullName == "Avalonia.Controls.IControl");
 
-        if (!isAvaloniaControl)
+        if (!clrType.IsAvaloniaControl())
             return node;
 
         foreach (var child in objectNode.Children)

--- a/src/Avalonia.NameGenerator/Generator/XamlXViewResolver.cs
+++ b/src/Avalonia.NameGenerator/Generator/XamlXViewResolver.cs
@@ -56,32 +56,15 @@ internal class XamlXViewResolver : IViewResolver, IXamlAstVisitor
             return null;
         }
     }
-
-    private bool IsAvaloniaControl(IXamlType clrType)
-    {
-		// Check for the base type since IControl interface is removed.
-		// https://github.com/AvaloniaUI/Avalonia/pull/9553
-		if (clrType.FullName == "Avalonia.Controls.Control")
-			return true;
-
-		if (clrType.BaseType != null)
-			return IsAvaloniaControl(clrType.BaseType);
-
-		return false;
-    }
-
+    
     IXamlAstNode IXamlAstVisitor.Visit(IXamlAstNode node)
     {
         if (node is not XamlAstObjectNode objectNode)
             return node;
 
         var clrType = objectNode.Type.GetClrType();
-        var isAvaloniaControl = IsAvaloniaControl(clrType) || clrType
-            .Interfaces
-            .Any(abstraction => abstraction.IsInterface &&
-                                abstraction.FullName == "Avalonia.Controls.IControl");
 
-        if (!isAvaloniaControl)
+        if (!clrType.IsAvaloniaControl())
             return node;
 
         foreach (var child in objectNode.Children)


### PR DESCRIPTION
`Avalonia.Controls.IControl` interface is removed with https://github.com/AvaloniaUI/Avalonia/pull/9553. This causes generator to find no views, therefore it doesn't generate any source code.

This PR adds a check for `Avalonia.Controls.Control` base type since it will be used from now on. I didn't remove the interface check so previous versions of Avalonia should still work correctly. Fixes #99